### PR TITLE
feat: read current version from maven pom.xml

### DIFF
--- a/src/main/java/io/jenkins/plugins/conventionalcommits/NextVersionStep.java
+++ b/src/main/java/io/jenkins/plugins/conventionalcommits/NextVersionStep.java
@@ -4,25 +4,20 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.io.LineReader;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
-import hudson.ExtensionList;
 import hudson.FilePath;
 import hudson.model.TaskListener;
-import hudson.remoting.DelegatingCallable;
-import hudson.remoting.VirtualChannel;
-import java.io.BufferedReader;
+
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.Nonnull;
-import jenkins.SlaveToMasterFileCallable;
-import org.apache.commons.lang.StringUtils;
+
+import io.jenkins.plugins.conventionalcommits.utils.CurrentVersion;
 import org.jenkinsci.plugins.workflow.steps.Step;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.jenkinsci.plugins.workflow.steps.StepDescriptor;
@@ -31,8 +26,6 @@ import org.jenkinsci.plugins.workflow.steps.SynchronousStepExecution;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
 import com.github.zafarkhaja.semver.Version;
-
-import static hudson.Util.fileToPath;
 
 public class NextVersionStep extends Step {
 
@@ -100,7 +93,8 @@ public class NextVersionStep extends Step {
                     }
                 }
 
-                Version currentVersion = Version.valueOf(latestTag.isEmpty() ? "0.0.0" : latestTag);
+                Version currentVersion = new CurrentVersion().getCurrentVersion(dir, latestTag);
+
                 String commitMessagesString = null;
                 if (latestTag.isEmpty()) {
                     commitMessagesString = execute(dir,"git", "log", "--pretty=format:%s").trim();

--- a/src/main/java/io/jenkins/plugins/conventionalcommits/utils/CurrentVersion.java
+++ b/src/main/java/io/jenkins/plugins/conventionalcommits/utils/CurrentVersion.java
@@ -1,0 +1,26 @@
+package io.jenkins.plugins.conventionalcommits.utils;
+
+import com.github.zafarkhaja.semver.Version;
+import java.io.File;
+import java.io.IOException;
+
+public class CurrentVersion {
+
+    private Version getCurrentVersionTag(String latestTag){
+        return Version.valueOf(latestTag.isEmpty() ? "0.0.0" : latestTag);
+    }
+
+    public Version getCurrentVersion(File directory, String latestTag) throws IOException, InterruptedException {
+
+        Version currentVersion;
+        ProjectType projectType = ProjectTypeFactory.getProjectType(directory);
+
+        if (projectType != null)
+            currentVersion = projectType.getCurrentVersion(directory);
+        else
+            currentVersion = getCurrentVersionTag(latestTag);
+
+        return  currentVersion;
+    }
+
+}

--- a/src/main/java/io/jenkins/plugins/conventionalcommits/utils/MavenProjectType.java
+++ b/src/main/java/io/jenkins/plugins/conventionalcommits/utils/MavenProjectType.java
@@ -1,0 +1,40 @@
+package io.jenkins.plugins.conventionalcommits.utils;
+
+import com.github.zafarkhaja.semver.Version;
+import org.apache.commons.io.IOUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class MavenProjectType extends ProjectType {
+
+    public boolean check(File directory){
+        return new File(directory, "pom.xml").exists();
+    }
+
+    @Override
+    public Version getCurrentVersion(File directory) throws IOException, InterruptedException{
+
+        String os = System.getProperty("os.name");
+        String commandName = "mvn";
+
+        if (os.contains("Windows")) {
+            commandName += ".cmd";
+        }
+
+        ProcessBuilder processBuilder = new ProcessBuilder(
+                commandName, "help:evaluate",
+                "-Dexpression=project.version", "-q", "-DforceStdout"
+        );
+
+        processBuilder.directory(directory);
+        Process process = processBuilder.start();
+
+        String results = IOUtils.toString(process.getInputStream(), StandardCharsets.UTF_8);
+        process.waitFor();
+
+        return Version.valueOf(results);
+    }
+
+}

--- a/src/main/java/io/jenkins/plugins/conventionalcommits/utils/ProjectType.java
+++ b/src/main/java/io/jenkins/plugins/conventionalcommits/utils/ProjectType.java
@@ -1,0 +1,13 @@
+package io.jenkins.plugins.conventionalcommits.utils;
+
+import java.io.File;
+import java.io.IOException;
+
+import com.github.zafarkhaja.semver.Version;
+
+abstract class ProjectType {
+
+    public abstract boolean check(File directory);
+    public abstract Version getCurrentVersion(File directory) throws IOException, InterruptedException;
+
+}

--- a/src/main/java/io/jenkins/plugins/conventionalcommits/utils/ProjectTypeFactory.java
+++ b/src/main/java/io/jenkins/plugins/conventionalcommits/utils/ProjectTypeFactory.java
@@ -1,0 +1,30 @@
+package io.jenkins.plugins.conventionalcommits.utils;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class ProjectTypeFactory {
+
+    static Map<String, ProjectType> projectTypeMap = new HashMap<>();
+    static {
+        projectTypeMap.put("maven", new MavenProjectType());
+    }
+
+    public static ProjectType getProjectType(File directory) {
+
+        ProjectType projectType = null;
+
+        for (Map.Entry<String,ProjectType> entryProjectType : projectTypeMap.entrySet()){
+            ProjectType candidate = entryProjectType.getValue();
+            if (candidate.check(directory)){
+                projectType = candidate;
+                break;
+            }
+        }
+
+        return projectType;
+    }
+
+}

--- a/src/test/java/io/jenkins/plugins/conventionalcommits/utils/CurrentVersionTest.java
+++ b/src/test/java/io/jenkins/plugins/conventionalcommits/utils/CurrentVersionTest.java
@@ -1,0 +1,72 @@
+package io.jenkins.plugins.conventionalcommits.utils;
+
+import com.github.zafarkhaja.semver.Version;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.hamcrest.CoreMatchers.*;
+
+public class CurrentVersionTest {
+
+    @Rule
+    public TemporaryFolder rootFolder = new TemporaryFolder();
+
+    @Test
+    public void testMavenProjectVersion() throws IOException, InterruptedException {
+
+        File mavenDir = rootFolder.newFolder("SampleMavenProject");
+        File pom = rootFolder.newFile(mavenDir.getName() + File.separator + "pom.xml");
+
+        String pomContent = "<project>\n" +
+                " <modelVersion>4.0.0</modelVersion>\n" +
+                " <groupId>com.test.app</groupId>\n" +
+                " <artifactId>test-app</artifactId>\n" +
+                " <version>1.0.0</version>\n" +
+                "</project>\n";
+
+        FileWriter pomWriter = new FileWriter(pom);
+        pomWriter.write(pomContent);
+        pomWriter.close();
+
+        Version actualCurrentVersion = Version.valueOf("1.0.0");
+        CurrentVersion currentVersion = new CurrentVersion();
+        Version testCurrentVersion = currentVersion.getCurrentVersion(mavenDir, "");
+
+        assertThat(testCurrentVersion, is(notNullValue()));
+        assertThat(actualCurrentVersion, is(testCurrentVersion));
+    }
+
+    @Test
+    public void CurrentVersion_NoProjectWithTag() throws IOException, InterruptedException {
+
+        File testDir = rootFolder.newFolder("SampleProject");
+        Version actualCurrentVersion = Version.valueOf("0.1.0");
+
+        CurrentVersion currentVersion = new CurrentVersion();
+        Version testCurrentVersion = currentVersion.getCurrentVersion(testDir, "0.1.0");
+
+        assertThat(testCurrentVersion, is(notNullValue()));
+        assertThat(actualCurrentVersion, is(testCurrentVersion));
+    }
+
+    @Test
+    public void CurrentVersion_NoProjectNoTag() throws IOException, InterruptedException {
+
+        File testDir = rootFolder.newFolder("SampleProject");
+        Version actualCurrentVersion = Version.valueOf("0.0.0");
+
+        CurrentVersion currentVersion = new CurrentVersion();
+        Version testCurrentVersion = currentVersion.getCurrentVersion(testDir, "");
+
+        assertThat(testCurrentVersion, is(notNullValue()));
+        assertThat(actualCurrentVersion, is(testCurrentVersion));
+    }
+
+}

--- a/src/test/java/io/jenkins/plugins/conventionalcommits/utils/ProjectTypeTest.java
+++ b/src/test/java/io/jenkins/plugins/conventionalcommits/utils/ProjectTypeTest.java
@@ -1,0 +1,40 @@
+package io.jenkins.plugins.conventionalcommits.utils;
+
+import com.github.zafarkhaja.semver.Version;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+
+import hudson.tasks.Maven;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import static org.hamcrest.MatcherAssert.*;
+import static org.junit.Assert.assertEquals;
+
+public class ProjectTypeTest {
+
+    @Rule
+    public TemporaryFolder rootFolder = new TemporaryFolder();
+
+    @Test
+    public void isMavenProject() throws IOException {
+
+        File mavenDir = rootFolder.newFolder("SampleMavenProject");
+        rootFolder.newFile(mavenDir.getName() + File.separator + "pom.xml");
+
+        ProjectType projectType = new MavenProjectType();
+        assertEquals(true, projectType.check(mavenDir));
+    }
+
+    @Test
+    public void isNotMavenProject() throws IOException {
+
+        File mavenDir = rootFolder.newFolder("SampleMavenProject");
+        ProjectType projectType = new MavenProjectType();
+        assertEquals(false, projectType.check(mavenDir));
+    }
+
+}


### PR DESCRIPTION
Fixes #5 

This commit:
- Checks whether the project directory contains a pom.xml
- If it does, then runs `mvn help:evaluate -DExpression=project.version` (along with other flags to suppress unwanted output" to get the current version
- If not, fallbacks to the latest tag approach (other project type support to be added in future)

The commit also adds tests for the added feature. All tests pass as of now.
Output of  `mvn test`:

![image](https://user-images.githubusercontent.com/39651310/122368922-60fc3300-cf7b-11eb-9ca9-bb6d0d697281.png)


<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
