### PR TITLE
fix: update breaking change footer 

### DIFF
--- a/src/main/java/io/jenkins/plugins/conventionalcommits/ConventionalCommits.java
+++ b/src/main/java/io/jenkins/plugins/conventionalcommits/ConventionalCommits.java
@@ -27,13 +27,18 @@ public class ConventionalCommits {
     }
 
     private boolean breakingChangeFooter(String commit){
-        int startIndex = commit.lastIndexOf("\n");
 
-        String result = commit;
+        boolean result = false;
+        String[] lines = commit.split("[\\r\\n]+");
 
-        if(startIndex!=-1 && startIndex!= commit.length()){
-            result = commit.substring(startIndex+1);
+        for(String line: lines){
+            if (line.startsWith("BREAKING CHANGE") || line.startsWith("BREAKING-CHANGE")) {
+                result = true;
+                break;
+            }
         }
-        return result.startsWith("BREAKING CHANGE");
+
+        return result;
     }
+
 }

--- a/src/main/java/io/jenkins/plugins/conventionalcommits/ConventionalCommits.java
+++ b/src/main/java/io/jenkins/plugins/conventionalcommits/ConventionalCommits.java
@@ -1,10 +1,15 @@
 package io.jenkins.plugins.conventionalcommits;
 
 import com.github.zafarkhaja.semver.Version;
+import io.jenkins.plugins.conventionalcommits.utils.LogUtils;
+
 import java.util.List;
+import java.util.logging.Level;
 import java.util.stream.Collectors;
 
 public class ConventionalCommits {
+
+    LogUtils logger = new LogUtils();
 
     private List<String> filterMergeCommits(List<String> commits) {
         return commits.stream().filter(s -> !s.startsWith("Merge")).collect(Collectors.toList());
@@ -12,7 +17,7 @@ public class ConventionalCommits {
 
     public Version nextVersion(Version in, List<String> commits) {
         List<String> filtered = filterMergeCommits(commits);
-        List<String> breaking = filtered.stream().filter(s -> s.contains("!:") || breakingChangeFooter(s) ).collect(Collectors.toList());
+        List<String> breaking = filtered.stream().filter(s -> s.contains("!:") || breakingChangeFooter(s)).collect(Collectors.toList());
         List<String> features = filtered.stream().filter(s -> s.startsWith("feat")).collect(Collectors.toList());
 
         if (!breaking.isEmpty()) {
@@ -26,15 +31,22 @@ public class ConventionalCommits {
         return in.incrementPatchVersion();
     }
 
-    private boolean breakingChangeFooter(String commit){
+    private boolean breakingChangeFooter(String commit) {
 
         boolean result = false;
         String[] lines = commit.split("[\\r\\n]+");
 
-        for(String line: lines){
+        for (String line : lines) {
             if (line.startsWith("BREAKING CHANGE:") || line.startsWith("BREAKING-CHANGE:")) {
                 result = true;
                 break;
+            } else if (line.toLowerCase().startsWith("breaking change:") || line.toLowerCase().startsWith("breaking-change:")) {
+                String keyword = line.substring(0, 16);
+                logger.log(
+                        Level.INFO, Level.INFO, Level.FINE, Level.FINE, true,
+                        "'" + keyword + "' detected which is not compliant with Conventional Commits Guidelines " +
+                                "(https://www.conventionalcommits.org/en/v1.0.0/#summary)"
+                );
             }
         }
 

--- a/src/main/java/io/jenkins/plugins/conventionalcommits/ConventionalCommits.java
+++ b/src/main/java/io/jenkins/plugins/conventionalcommits/ConventionalCommits.java
@@ -32,7 +32,7 @@ public class ConventionalCommits {
         String[] lines = commit.split("[\\r\\n]+");
 
         for(String line: lines){
-            if (line.startsWith("BREAKING CHANGE") || line.startsWith("BREAKING-CHANGE")) {
+            if (line.startsWith("BREAKING CHANGE:") || line.startsWith("BREAKING-CHANGE:")) {
                 result = true;
                 break;
             }

--- a/src/main/java/io/jenkins/plugins/conventionalcommits/utils/LogUtils.java
+++ b/src/main/java/io/jenkins/plugins/conventionalcommits/utils/LogUtils.java
@@ -1,0 +1,39 @@
+package io.jenkins.plugins.conventionalcommits.utils;
+
+
+import io.jenkins.plugins.conventionalcommits.ConventionalCommits;
+
+import java.util.logging.ConsoleHandler;
+import java.util.logging.Handler;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class LogUtils {
+
+    private static final Logger LOGGER = Logger.getLogger(ConventionalCommits.class.getName());
+    private static Handler consoleHandler = new ConsoleHandler();
+
+    private void beforeLogging(Level loggerLevel, Level consoleLevel){
+        LOGGER.setLevel(loggerLevel);
+        consoleHandler.setLevel(consoleLevel);
+        LOGGER.addHandler(consoleHandler);
+    }
+
+    private void afterLogging(Level loggerLevel, Level consoleLevel){
+        LOGGER.removeHandler(consoleHandler);
+        LOGGER.setLevel(loggerLevel);
+        consoleHandler.setLevel(consoleLevel);
+    }
+
+    public void log(Level initialLogLevel, Level initialConsoleLevel, Level requiredLogLevel,
+                    Level requiredConsoleLevel, boolean revertAfterLogging, String message) {
+        /*
+            revertAfterLogging (boolean): revert to initial log and console level after logging the current log string
+         */
+
+        beforeLogging(requiredLogLevel, requiredConsoleLevel);
+        LOGGER.log(requiredLogLevel, message);
+        if (revertAfterLogging)
+            afterLogging(initialLogLevel, initialConsoleLevel);
+    }
+}

--- a/src/test/java/io/jenkins/plugins/conventionalcommits/ConventionalCommitsTest.java
+++ b/src/test/java/io/jenkins/plugins/conventionalcommits/ConventionalCommitsTest.java
@@ -138,4 +138,17 @@ public class ConventionalCommitsTest {
         assertThat(out, is(notNullValue()));
         assertThat(out.toString(), is("1.0.0"));
     }
+
+    @Test
+    public void willNotBumpMajorVersion_BreakingChangeCaseSensitivity() {
+        ConventionalCommits cc = new ConventionalCommits();
+        Version out = cc.nextVersion(Version.valueOf("0.0.1"), Arrays.asList(
+                "feat: add new feature",
+                "fix: bug fix \nBreaking Change: breaking change",
+                "fix: bug fix \nBREAKING change: breaking change"
+                ));
+
+        assertThat(out, is(notNullValue()));
+        assertThat(out.toString(), is("0.1.0"));
+    }
 }

--- a/src/test/java/io/jenkins/plugins/conventionalcommits/ConventionalCommitsTest.java
+++ b/src/test/java/io/jenkins/plugins/conventionalcommits/ConventionalCommitsTest.java
@@ -105,14 +105,14 @@ public class ConventionalCommitsTest {
     }
 
     @Test
-    public void willNotBumpMajorVersion_ExclamationMultipleLineCommitNotFooter() {
+    public void willBumpMajorVersion_ExclamationMultipleLineCommitNotFooter() {
         ConventionalCommits cc = new ConventionalCommits();
 
         Version out = cc.nextVersion(Version.valueOf("0.0.1"), Collections.singletonList(
-                "chore: new major version \nBREAKING CHANGE: new breaking change \nstupid footer"
+                "chore: new major version \nBREAKING CHANGE: new breaking change \nextra footer"
         ));
         assertThat(out, is(notNullValue()));
-        assertThat(out.toString(), is("0.0.2"));
+        assertThat(out.toString(), is("1.0.0"));
     }
 
     @Test


### PR DESCRIPTION
see #22 

This PR updates the breakingChangeFooter code to consider additional test cases
The following were added/considered:
1. BREAKING-CHANGE used in lieu of BREAKING CHANGE
2. Use of breaking change in any footer (including but not limited to ultimate or penultimate footer)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


Signed-off-by: Aditya Srivastava <adityasrivastava301199@gmail.com>
