### PR TITLE
feat: add build metadata support

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,32 @@ pipeline {
 }
 ```
 
+## Using Optional Parameters
+
+The plugin provides provision to use optional parameters for support of build metadata, pre-release information, settnig the start tag, etc.
+
+### Build Metadata 
+
+`buildMetadata` an optional parameter can be added as follows:
+
+```
+pipeline {
+    agent any
+    environment {
+        NEXT_VERSION = nextVersion(buildMetadata: '001')
+    }
+    stages {
+        stage('Hello') {
+            steps {
+                echo "next version = ${NEXT_VERSION}"
+            }
+        }
+    }
+}
+```
+Assuming next version is `1.1.0`.
+The pipeline will output :`next version = 1.1.0+001`
+
 ## Issues
 
 Report issues and enhancements in the [Github issue tracker](https://github.com/jenkinsci/conventional-commits/issues).

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ The plugin provides provision to use optional parameters for support of build me
 pipeline {
     agent any
     environment {
-        NEXT_VERSION = nextVersion(buildMetadata: '001')
+        NEXT_VERSION = nextVersion(buildMetadata: "$env.BUILD_NUMBER")
     }
     stages {
         stage('Hello') {
@@ -74,4 +74,3 @@ Refer to our [contribution guidelines](https://github.com/jenkinsci/.github/blob
 ## LICENSE
 
 Licensed under MIT, see [LICENSE](LICENSE.md)
-

--- a/src/test/java/io/jenkins/plugins/conventionalcommits/JenkinsTest.java
+++ b/src/test/java/io/jenkins/plugins/conventionalcommits/JenkinsTest.java
@@ -135,4 +135,31 @@ public class JenkinsTest {
     assertThat(JenkinsRule.getLog(b), containsString("next version = 0.1.1"));
     assertThat(JenkinsRule.getLog(b), containsString("Finished: SUCCESS"));
   }
+
+  @Test
+  public void shouldAddBuildMetadataInformation() throws Exception {
+    WorkflowJob p = rule.jenkins.createProject(WorkflowJob.class, "p");
+    URL zipFile = getClass().getResource("simple-project-with-notags.zip");
+    assertThat(zipFile, is(notNullValue()));
+
+    p.setDefinition(
+        new CpsFlowDefinition(
+            "node {\n"
+                + "  unzip '"
+                + zipFile.getPath()
+                + "'\n"
+                + "  nextVersion(buildMetadata: '001')\n"
+                + "}\n",
+            true));
+
+    WorkflowRun b = rule.assertBuildStatus(Result.SUCCESS, p.scheduleBuild2(0).get());
+
+    System.out.println(JenkinsRule.getLog(b));
+
+    assertThat(JenkinsRule.getLog(b), containsString("Started"));
+    assertThat(JenkinsRule.getLog(b), containsString("nextVersion"));
+    assertThat(JenkinsRule.getLog(b), containsString("No tags found"));
+    assertThat(JenkinsRule.getLog(b), containsString("0.1.0+001"));
+    assertThat(JenkinsRule.getLog(b), containsString("Finished: SUCCESS"));
+  }
 }


### PR DESCRIPTION
fixes #24 

This pull request adds the optional parameter buildMetadata, thus enabling the addition/support of build metadata to the semantic version.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue


Signed-off-by: Aditya Srivastava <adityasrivastava301199@gmail.com>
