### PR TITLE
fix: make buildMetadata transient

### DIFF
--- a/src/main/java/io/jenkins/plugins/conventionalcommits/NextVersionStep.java
+++ b/src/main/java/io/jenkins/plugins/conventionalcommits/NextVersionStep.java
@@ -118,7 +118,7 @@ public class NextVersionStep extends Step {
     @SuppressFBWarnings(
         value = "SE_TRANSIENT_FIELD_NOT_RESTORED",
         justification = "Only used when starting.")
-    private final String buildMetadata;
+    private final transient String buildMetadata;
 
     protected Execution(
         String outputFormat,


### PR DESCRIPTION
Makes the buildMetada field transient

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
Signed-off-by: Aditya Srivastava <adityasrivastava301199@gmail.com>
