### PR TITLE
feat: add writeVersion for maven project

### DIFF
--- a/src/main/java/io/jenkins/plugins/conventionalcommits/utils/GradleProjectType.java
+++ b/src/main/java/io/jenkins/plugins/conventionalcommits/utils/GradleProjectType.java
@@ -40,4 +40,8 @@ public class GradleProjectType extends ProjectType {
     }
     return Version.valueOf(version);
   }
+
+  @Override
+  public void writeVersion(File directory, Version nextVersion, ProcessHelper processHelper)
+      throws IOException, InterruptedException {}
 }

--- a/src/main/java/io/jenkins/plugins/conventionalcommits/utils/HelmProjectType.java
+++ b/src/main/java/io/jenkins/plugins/conventionalcommits/utils/HelmProjectType.java
@@ -49,4 +49,8 @@ public class HelmProjectType extends ProjectType {
             HelmChart.class);
     return Version.valueOf(chart.getVersion());
   }
+
+  @Override
+  public void writeVersion(File directory, Version nextVersion, ProcessHelper processHelper)
+      throws IOException, InterruptedException {}
 }

--- a/src/main/java/io/jenkins/plugins/conventionalcommits/utils/MakeProjectType.java
+++ b/src/main/java/io/jenkins/plugins/conventionalcommits/utils/MakeProjectType.java
@@ -41,4 +41,8 @@ public class MakeProjectType extends ProjectType {
 
     return Version.valueOf(results);
   }
+
+  @Override
+  public void writeVersion(File directory, Version nextVersion, ProcessHelper processHelper)
+      throws IOException, InterruptedException {}
 }

--- a/src/main/java/io/jenkins/plugins/conventionalcommits/utils/MavenProjectType.java
+++ b/src/main/java/io/jenkins/plugins/conventionalcommits/utils/MavenProjectType.java
@@ -32,4 +32,21 @@ public class MavenProjectType extends ProjectType {
 
     return Version.valueOf(results);
   }
+
+  @Override
+  public void writeVersion(File directory, Version nextVersion, ProcessHelper processHelper)
+      throws IOException, InterruptedException {
+
+    String os = System.getProperty("os.name");
+    String commandName = "mvn";
+
+    if (os.contains("Windows")) {
+      commandName += ".cmd";
+    }
+
+    List<String> command =
+        Arrays.asList(
+            commandName, "versions:set", "-DnewVersion=" + nextVersion.toString());
+    processHelper.runProcessBuilder(directory, command);
+  }
 }

--- a/src/main/java/io/jenkins/plugins/conventionalcommits/utils/NpmProjectType.java
+++ b/src/main/java/io/jenkins/plugins/conventionalcommits/utils/NpmProjectType.java
@@ -47,4 +47,7 @@ public class NpmProjectType extends ProjectType {
 
     return Version.valueOf((String) map.get("version"));
   }
+
+  @Override
+  public void writeVersion(File directory, Version nextVersion, ProcessHelper processHelper) {}
 }

--- a/src/main/java/io/jenkins/plugins/conventionalcommits/utils/ProjectType.java
+++ b/src/main/java/io/jenkins/plugins/conventionalcommits/utils/ProjectType.java
@@ -11,4 +11,8 @@ abstract class ProjectType {
 
   public abstract Version getCurrentVersion(File directory, ProcessHelper processHelper)
       throws IOException, InterruptedException;
+
+  public abstract void writeVersion(
+      File directory, Version nextVersion, ProcessHelper processHelper)
+      throws IOException, InterruptedException;
 }

--- a/src/main/java/io/jenkins/plugins/conventionalcommits/utils/PythonProjectType.java
+++ b/src/main/java/io/jenkins/plugins/conventionalcommits/utils/PythonProjectType.java
@@ -75,4 +75,8 @@ public class PythonProjectType extends ProjectType {
 
     return Version.valueOf(result);
   }
+
+  @Override
+  public void writeVersion(File directory, Version nextVersion, ProcessHelper processHelper)
+      throws IOException, InterruptedException {}
 }

--- a/src/main/java/io/jenkins/plugins/conventionalcommits/utils/WriteVersion.java
+++ b/src/main/java/io/jenkins/plugins/conventionalcommits/utils/WriteVersion.java
@@ -1,0 +1,40 @@
+package io.jenkins.plugins.conventionalcommits.utils;
+
+import com.github.zafarkhaja.semver.Version;
+import io.jenkins.plugins.conventionalcommits.process.DefaultProcessHelper;
+import io.jenkins.plugins.conventionalcommits.process.ProcessHelper;
+import java.io.File;
+import java.io.IOException;
+import java.util.logging.Level;
+
+/** Class to write back the calculated next semantic version into the config file of a project. */
+public class WriteVersion {
+  private ProcessHelper processHelper;
+
+  public void setProcessHelper(ProcessHelper processHelper) {
+    this.processHelper = processHelper;
+  }
+
+  /**
+   * Writes next semantic version in a file.
+   *
+   * @param nextVersion The project's calculated next semantic version.
+   * @param directory Directory of the project
+   * @throws IOException If an error occurs while reading/writing files.
+   * @throws InterruptedException If an error occurs while executing command using processHelper.
+   */
+  public void write(Version nextVersion, File directory) throws IOException, InterruptedException {
+
+    ProjectType projectType = ProjectTypeFactory.getProjectType(directory);
+
+    if (projectType != null) {
+      if (processHelper == null) {
+        processHelper = new DefaultProcessHelper();
+      }
+      projectType.writeVersion(directory, nextVersion, processHelper);
+    } else {
+      LogUtils logger = new LogUtils();
+      logger.log(Level.INFO, Level.INFO, Level.FINE, Level.FINE, true, "Could not write to file");
+    }
+  }
+}


### PR DESCRIPTION
fixes #80 

This PR:
1. Adds an optional "writeVersion" parameter for the user to toggle the write functionality.
2. Extends the project type abstract class to support "writeVersion" method
3. Adds WriteVersion class that leverages the factory pattern and uses the "write" method to write the next version in a file
4. Sets the method in a maven project using the `mvn versions:set -DnewVersion=x.y.z` command

**_Note_**: As the abstract class got changed all the `*ProjectType` classes extending it now implement an empty `write` method (except the MavenProjectType class ofc)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

Signed-off-by: Aditya Srivastava <adityasrivastava301199@gmail.com>
