### PR TITLE
refactor: Used contains instead of startsWith

### DIFF
--- a/src/main/java/io/jenkins/plugins/conventionalcommits/utils/GradleProjectType.java
+++ b/src/main/java/io/jenkins/plugins/conventionalcommits/utils/GradleProjectType.java
@@ -39,7 +39,7 @@ public class GradleProjectType extends ProjectType {
 
     String[] resultLines = results.split("[\\r\\n]+");
     for (String line : resultLines) {
-      if (line.startsWith("version:")) {
+      if (line.contains("version:")) {
         String[] words = line.split(" ");
         version = words[1];
         break;

--- a/src/main/java/io/jenkins/plugins/conventionalcommits/utils/MakeProjectType.java
+++ b/src/main/java/io/jenkins/plugins/conventionalcommits/utils/MakeProjectType.java
@@ -30,9 +30,7 @@ public class MakeProjectType extends ProjectType {
 
     while (scanner.hasNextLine()) {
       String line = scanner.nextLine();
-      if (line.toLowerCase().startsWith("version ") || line.toLowerCase().startsWith("version")
-          || line.toLowerCase().startsWith("version:") 
-          || line.toLowerCase().startsWith("version :")) {
+      if (line.toLowerCase().contains("version")) {
         String[] words = line.split("=");
         results = words[1].trim();
         break;

--- a/src/main/java/io/jenkins/plugins/conventionalcommits/utils/ProjectType.java
+++ b/src/main/java/io/jenkins/plugins/conventionalcommits/utils/ProjectType.java
@@ -50,8 +50,7 @@ abstract class ProjectType {
               StandardCharsets.UTF_8)) {
         while ((line = reader.readLine()) != null) {
           if (!isVersionTag && Arrays.stream(matchingWords)
-                  .anyMatch(isIndented ? line.toLowerCase()::contains :
-                          line.toLowerCase()::startsWith)) {
+                  .anyMatch(line.toLowerCase()::contains)) {
             String[] words = line.split("=");
             currentVersion = words[1].trim();
             if (currentVersion.contains("\"")) {

--- a/src/main/java/io/jenkins/plugins/conventionalcommits/utils/PythonProjectType.java
+++ b/src/main/java/io/jenkins/plugins/conventionalcommits/utils/PythonProjectType.java
@@ -58,7 +58,7 @@ public class PythonProjectType extends ProjectType {
 
       while (scanner.hasNextLine()) {
         String line = scanner.nextLine();
-        if (line.toLowerCase().startsWith("version ") || line.toLowerCase().startsWith("version")) {
+        if (line.toLowerCase().contains("version")) {
           String[] words = line.split("=");
           result = words[1].trim();
           break;


### PR DESCRIPTION
Fix [#142](https://github.com/jenkinsci/conventional-commits-plugin/issues/142)

Replaced startsWith with contains in 4 files, GradleProjectType.java, MakeProjectType.java, ProjectType.java, and PythonProjectType.java

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
