### PR TITLE
feat: Add support to Go projects for reading the current version

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,9 @@ The supported configurations files :
  - pom.xml (Maven) : need the Maven CLI in the path,
  - package.json (NPM) : need the Npm CLI in the path,
  - chart.yaml (Helm),
- - build.gradle / gradle.properties (Gradle).
+ - build.gradle / gradle.properties (Gradle),
+ - setup.py / setup.cfg / pyproject.toml (Python),
+ - go.mod (GoLang).
 
 Example of use :
 With a project with a package.json as follows :
@@ -169,7 +171,7 @@ pipeline {
     }
 }
 ```
-Will update the _package.json_ as follow :
+Will update the _package.json_ as follows :
 ```json
 {
   "name": "conventional-commits-plugin-example-npm",

--- a/src/main/java/io/jenkins/plugins/conventionalcommits/utils/GoProjectType.java
+++ b/src/main/java/io/jenkins/plugins/conventionalcommits/utils/GoProjectType.java
@@ -6,6 +6,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.lang.NotImplementedException;
@@ -49,7 +50,7 @@ public class GoProjectType extends ProjectType {
     String result = "";
 
     // Compiles the regex to create desired version pattern for finding the current version
-    String versionRegex = "^v[0-9]+.[0-9]+.[0-9]+(-((\\balpha\\b)|(\\bbeta\\b)).[0-9])?$";
+    String versionRegex = "v[0-9]+.[0-9]+.[0-9]+(-((\\balpha\\b)|(\\bbeta\\b)).[0-9])?";
     Pattern pattern = Pattern.compile(versionRegex);
 
     if (checkGoMod(directory)) {
@@ -82,7 +83,9 @@ public class GoProjectType extends ProjectType {
   public void writeVersion(File directory, Version nextVersion, ProcessHelper processHelper)
       throws IOException, InterruptedException, NotImplementedException {
     if (checkGoMod(directory)) {
-      System.out.println("The go.mod file already exists");
+      String message = "The go.mod file already exists";
+      LogUtils logger = new LogUtils();
+      logger.log(Level.INFO, Level.INFO, Level.FINE, Level.FINE, true, message);
     } else {
       throw new NotImplementedException("Project not supported");
     }

--- a/src/main/java/io/jenkins/plugins/conventionalcommits/utils/GoProjectType.java
+++ b/src/main/java/io/jenkins/plugins/conventionalcommits/utils/GoProjectType.java
@@ -1,0 +1,90 @@
+package io.jenkins.plugins.conventionalcommits.utils;
+
+import com.github.zafarkhaja.semver.Version;
+import io.jenkins.plugins.conventionalcommits.process.ProcessHelper;
+import java.io.File;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.commons.lang.NotImplementedException;
+
+/**
+ * Represents a Go project type.
+ * Projects with the go.mod file are supported.
+ */
+public class GoProjectType extends ProjectType {
+
+  private boolean checkGoMod(File directory) {
+    return new File(directory, "go.mod").exists();
+  }
+
+  /**
+   * Checks if the go.mod config file exists at the root directory.
+   *
+   * @param directory The directory in which the go.mod file is searched for.
+   * @return A boolean true / false is returned.
+   */
+  @Override
+  public boolean check(File directory) {
+    return checkGoMod(directory);
+  }
+
+  /**
+   * Gets the current version of the Go module as indicated by release tag on GitHub.
+   *
+   * @param directory The directory in which the go.mod file is ideally found.
+   * @param processHelper The helper to run the "go list" command.
+   * @return The current version of the Go module concerned.
+   * @throws IOException If an error is thrown while file is read.
+   * @throws InterruptedException If an error is thrown due to interruption.
+   */
+  @Override
+  public Version getCurrentVersion(File directory, ProcessHelper processHelper)
+      throws IOException, InterruptedException {
+
+    String commandName = "go";
+
+    String result = "";
+
+    // Compiles the regex to create desired version pattern for finding the current version
+    String versionRegex = "^v[0-9]+.[0-9]+.[0-9]+(-((\\balpha\\b)|(\\bbeta\\b)).[0-9])?$";
+    Pattern pattern = Pattern.compile(versionRegex);
+
+    if (checkGoMod(directory)) {
+      List<String> command = Arrays.asList(commandName, "list", "-m", "-versions");
+      String longResult = processHelper.runProcessBuilder(directory, command);
+      Matcher match = pattern.matcher(longResult);
+      // The last version should be the most current version
+      // The result variable is overwritten by the last version in the while loop
+      while (match.find()) {
+        result = match.group();
+      }
+    }
+    result = result.substring(1);
+    return Version.valueOf(result.trim());
+  }
+
+  /**
+   * Check if there is a Go config file (go.mod) file in the directory.
+   * If that's the case change the file will remain the same.
+   * This is because for Go modules the release version is from GitHub repository tags.
+   *
+   * @param directory The directory to which the file is written.
+   * @param nextVersion The next version to use.
+   * @param processHelper The helper to run the command (not used here).
+   * @throws NotImplementedException If not implemented means the Go project is not supported.
+   * @throws IOException If an error is thrown while file is read.
+   * @throws InterruptedException If an error is thrown due to interruption.
+   */
+  @Override
+  public void writeVersion(File directory, Version nextVersion, ProcessHelper processHelper)
+      throws IOException, InterruptedException, NotImplementedException {
+    if (checkGoMod(directory)) {
+      System.out.println("The go.mod file already exists");
+    } else {
+      throw new NotImplementedException("Project not supported");
+    }
+  }
+}

--- a/src/main/java/io/jenkins/plugins/conventionalcommits/utils/ProjectTypeFactory.java
+++ b/src/main/java/io/jenkins/plugins/conventionalcommits/utils/ProjectTypeFactory.java
@@ -16,6 +16,7 @@ public class ProjectTypeFactory {
     projectTypeMap.put("npm", new NpmProjectType());
     projectTypeMap.put("python", new PythonProjectType());
     projectTypeMap.put("helm", new HelmProjectType());
+    projectTypeMap.put("go", new GoProjectType());
   }
 
   /**

--- a/src/test/java/io/jenkins/plugins/conventionalcommits/utils/GoProjectTypeTest.java
+++ b/src/test/java/io/jenkins/plugins/conventionalcommits/utils/GoProjectTypeTest.java
@@ -1,0 +1,61 @@
+package io.jenkins.plugins.conventionalcommits.utils;
+
+import com.github.zafarkhaja.semver.Version;
+import io.jenkins.plugins.conventionalcommits.process.ProcessHelper;
+import org.hamcrest.core.IsEqual;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class GoProjectTypeTest {
+  @Rule
+  public TemporaryFolder rootFolder = new TemporaryFolder();
+
+  @Mock
+  private ProcessHelper mockProcessHelper;
+
+  private void createGoMod(File goDir) throws Exception {
+    Files.deleteIfExists(Paths.get(goDir.getPath() + File.separator + "go.mod"));
+    File goMod = rootFolder.newFile(goDir.getName() + File.separator + "go.mod");
+    String configContent =
+      "module github.com/slim-patchy/hey\n" +
+        "\n" +
+        "require (\n" +
+        "\tgolang.org/x/net v0.0.0-20191009170851-d66e71096ffb\n" +
+        "\tgolang.org/x/text v0.3.2 // indirect\n" +
+        ")\n" +
+        "\n" +
+        "go 1.13\n";
+    FileWriter goWriter = new FileWriter(goMod);
+    goWriter.write(configContent);
+    goWriter.close();
+  }
+
+  @Test
+  public void shouldGetCurrentVersionForAGoMod() throws Exception {
+    // Given a Go project with a go.mod
+    File goDir = rootFolder.newFolder("SampleGoProject");
+    createGoMod(goDir);
+    when(mockProcessHelper.runProcessBuilder(any(), any())).thenReturn("v0.1.4");
+
+    // Asking to have the current version of the project
+    GoProjectType goProjectType = new GoProjectType();
+    Version readVersion = goProjectType.getCurrentVersion(goDir, mockProcessHelper);
+
+    // The current version is returned
+    assertThat(readVersion, IsEqual.equalTo(Version.valueOf("0.1.4")));
+  }
+}

--- a/src/test/java/io/jenkins/plugins/conventionalcommits/utils/GoProjectTypeTest.java
+++ b/src/test/java/io/jenkins/plugins/conventionalcommits/utils/GoProjectTypeTest.java
@@ -49,7 +49,12 @@ public class GoProjectTypeTest {
     // Given a Go project with a go.mod
     File goDir = rootFolder.newFolder("SampleGoProject");
     createGoMod(goDir);
-    when(mockProcessHelper.runProcessBuilder(any(), any())).thenReturn("v0.1.4");
+    when(mockProcessHelper.runProcessBuilder(any(), any())).thenReturn("go list -m: " +
+        "loading module retractions for github.com/krisstern/hey@v0.1.0: " +
+        "verifying go.mod: github.com/krisstern/hey@v0.1.4/go.mod: " +
+        "initializing sumdb.Client: " +
+        "open /opt/homebrew/bin/go/pkg/sumdb/sum.golang.org/latest: " +
+        "not a directory");
 
     // Asking to have the current version of the project
     GoProjectType goProjectType = new GoProjectType();

--- a/src/test/java/io/jenkins/plugins/conventionalcommits/utils/ProjectTypeTest.java
+++ b/src/test/java/io/jenkins/plugins/conventionalcommits/utils/ProjectTypeTest.java
@@ -122,4 +122,19 @@ public class ProjectTypeTest {
     ProjectType projectType = new PythonProjectType();
     assertTrue(projectType.check(pyDir));
   }
+
+  @Test
+  public void isGoProject() throws IOException {
+    File goDir = rootFolder.newFolder("SampleGoProject");
+    rootFolder.newFile(goDir.getName() + File.separator + "go.mod");
+    ProjectType projectType = new GoProjectType();
+    assertEquals(true, projectType.check(goDir));
+  }
+
+  @Test
+  public void isNotGoProject() throws IOException {
+    File goDir = rootFolder.newFolder("SampleGoProject");
+    ProjectType projectType = new GoProjectType();
+    assertFalse(projectType.check(goDir));
+  }
 }


### PR DESCRIPTION
Fixes #118 

<!-- Please describe your pull request here. -->

## Description
Added support for reading current version of Go project from the repository itself. Two parts: Code addition and minor doc edit:
1. Added a `GoProjectType.java` class for checking for the existence of the `go.mod` file in the repository, getting the current version of the Go module using the `go list -m -versions` command, and symbolically writing the version to file as it is not the customary practice to include version detail(s) in the Go config file `go.mod`. 
2. Added a `GoProjectTypeTest.java` class to add the relevant test for this new Go support code. 
3. Modified the `ProjectTypeTest.java` class to include test for Go modules. 
4. Updated the `README.md` file to include details for adding Go support. 

## PR Checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
