### PR TITLE
Add PHP support to read current version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,10 +9,10 @@
     </parent>
     <groupId>io.jenkins.plugins</groupId>
     <artifactId>conventional-commits</artifactId>
-    <version>0.0.1-SNAPSHOT</version>
+    <version>0.10.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-        <jenkins.version>2.324</jenkins.version>
+        <jenkins.version>2.334</jenkins.version>
         <java.level>8</java.level>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <checkstyle.config.location>google_checks.xml</checkstyle.config.location>
@@ -142,6 +142,14 @@
                         <version>9.3</version>
                     </dependency>
                 </dependencies>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>11</source>
+                    <target>11</target>
+                </configuration>
             </plugin>
         </plugins>
     </build>

--- a/pom.xml
+++ b/pom.xml
@@ -147,8 +147,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>

--- a/src/main/java/io/jenkins/plugins/conventionalcommits/utils/GoProjectType.java
+++ b/src/main/java/io/jenkins/plugins/conventionalcommits/utils/GoProjectType.java
@@ -68,8 +68,8 @@ public class GoProjectType extends ProjectType {
   }
 
   /**
-   * Check if there is a Go config file (go.mod) file in the directory.
-   * If that's the case change the file will remain the same.
+   * Checks if there is a Go config file (go.mod) file in the directory.
+   * If that's the case then the file will remain the same.
    * This is because for Go modules the release version is from GitHub repository tags.
    *
    * @param directory The directory to which the file is written.

--- a/src/main/java/io/jenkins/plugins/conventionalcommits/utils/PhpProjectType.java
+++ b/src/main/java/io/jenkins/plugins/conventionalcommits/utils/PhpProjectType.java
@@ -1,0 +1,92 @@
+package io.jenkins.plugins.conventionalcommits.utils;
+
+import com.github.zafarkhaja.semver.Version;
+import io.jenkins.plugins.conventionalcommits.process.ProcessHelper;
+import io.jenkins.plugins.conventionalcommits.process.ProcessUtil;
+import java.io.File;
+import java.io.IOException;
+import java.util.Scanner;
+import java.util.logging.Level;
+import org.json.JSONObject;
+
+/**
+ * Represents a PHP project type.
+ * Projects managed by Composer with the composer.json file are supported.
+ */
+public class PhpProjectType extends ProjectType {
+
+  private boolean checkComposerJson(File directory) {
+    return new File(directory, "composer.json").exists();
+  }
+
+  /**
+   * Checks if the composer.json config file exists at the root directory.
+   *
+   * @param directory The directory in which the composer.json file is searched for.
+   * @return A boolean true / false is returned.
+   */
+  @Override
+  public boolean check(File directory) {
+    return checkComposerJson(directory);
+  }
+
+  /**
+   * Gets the current version of the composer.json file if explicitly defined.
+   * If version is not stored in composer.json then resort to using the latest Git tag.
+   *
+   * @param directory The directory in which the composer.json file is ideally found.
+   * @param processHelper The helper to scan the json file for version property.
+   * @return The current version of the PHP package concerned.
+   * @throws IOException If an error is thrown while file is read.
+   * @throws InterruptedException If an error is thrown due to interruption.
+   */
+  @Override
+  public Version getCurrentVersion(File directory, ProcessHelper processHelper)
+      throws IOException, InterruptedException {
+
+    String result = "";
+    String composerJson;
+
+    // Check if a version property has been set in composer.json
+    if (checkComposerJson(directory)) {
+      String filePath = directory.getAbsolutePath() + File.separator + "composer.json";
+      try (Scanner scanner = new Scanner(new File(filePath), "UTF-8")) {
+        composerJson = scanner.useDelimiter("\\A").next();
+      }
+      JSONObject composerJsonObject = new JSONObject(composerJson);
+      if (composerJsonObject.has("version")) {
+        result = (String) composerJsonObject.get("version");
+      } else {
+        try {
+          result = ProcessUtil.execute(directory, "git", "describe", "--abbrev=0", "--tags").trim();
+        } catch (IOException exp) {
+          String message = "No Git tags found";
+          LogUtils logger = new LogUtils();
+          logger.log(Level.INFO, Level.INFO, Level.FINE, Level.FINE, true, message);
+        }
+      }
+    }
+    return Version.valueOf(result.trim());
+  }
+
+  /**
+   * Checks if there is a composer.json file in the directory.
+   * If that's the case then the file will remain the same.
+   * If no composer.json file is found no error is thrown.
+   *
+   * @param directory The directory to which the file is written.
+   * @param nexVersion The next version to use.
+   * @param processHelper The helper to run the command (not used here).
+   * @throws IOException If an error is thrown while file is read.
+   * @throws InterruptedException If an error is thrown due to interruption.
+   */
+  @Override
+  public void writeVersion(File directory, Version nexVersion, ProcessHelper processHelper)
+      throws IOException, InterruptedException {
+    if (checkComposerJson(directory)) {
+      String message = "The composer.json file already exists";
+      LogUtils logger = new LogUtils();
+      logger.log(Level.INFO, Level.INFO, Level.FINE, Level.FINE, true, message);
+    }
+  }
+}

--- a/src/main/java/io/jenkins/plugins/conventionalcommits/utils/ProjectTypeFactory.java
+++ b/src/main/java/io/jenkins/plugins/conventionalcommits/utils/ProjectTypeFactory.java
@@ -17,6 +17,7 @@ public class ProjectTypeFactory {
     projectTypeMap.put("python", new PythonProjectType());
     projectTypeMap.put("helm", new HelmProjectType());
     projectTypeMap.put("go", new GoProjectType());
+    projectTypeMap.put("php", new PhpProjectType());
   }
 
   /**

--- a/src/test/java/io/jenkins/plugins/conventionalcommits/utils/PhpProjectTypeTest.java
+++ b/src/test/java/io/jenkins/plugins/conventionalcommits/utils/PhpProjectTypeTest.java
@@ -1,0 +1,55 @@
+package io.jenkins.plugins.conventionalcommits.utils;
+
+import com.github.zafarkhaja.semver.Version;
+import io.jenkins.plugins.conventionalcommits.process.ProcessHelper;
+import org.hamcrest.core.IsEqual;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.MockitoJUnitRunner;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+
+@RunWith(MockitoJUnitRunner.class)
+public class PhpProjectTypeTest {
+  @Rule
+  public TemporaryFolder rootFolder = new TemporaryFolder();
+
+  @Mock
+  private ProcessHelper mockProcessHelper;
+
+  private void createComposerJson(File phpDir) throws Exception {
+    Files.deleteIfExists(Paths.get(phpDir.getPath() + File.separator + "composer.json"));
+    File composerJson = rootFolder.newFile(phpDir.getName() + File.separator + "composer.json");
+    String configContent = "{\"name\":\"someentity/example\",\"minimum-stability\":\"dev\",\"authors\":[{\"name\":\"SomeProgrammer\",\"email\":\"some.programmer@company.com\"}],\"version\":\"0.10.0\",\"require\":{\"composer/installers\":\"^1.0.20\",\"drupal/file_browser\":\"dev-1.x\",\"drupal/entity_embed\":\"dev-1.x\",\"drupal/entity_browser\":\"dev-1.x\",\"drupal/dropzonejs\":\"dev-1.x\",\"enyo/dropzone\":\"4.2.0\",\"desandro/masonry\":\"3.3.1\",\"desandro/imagesloaded\":\"3.1.8\"}}";
+    FileWriter phpWriter = new FileWriter(composerJson);
+    phpWriter.write(configContent);
+    phpWriter.close();
+  }
+
+  @Test
+  public void shouldGetCurrentVersionForAComposerJson() throws Exception {
+    // Given a PHP project with a composer.json
+    File phpDir = rootFolder.newFolder("SamplePhpProject");
+    createComposerJson(phpDir);
+    Mockito.lenient().when(mockProcessHelper.runProcessBuilder(any(), any())).thenReturn(
+        "0.10.0"
+    );
+
+    // Asking to have the current version of the project
+    PhpProjectType phpProjectType = new PhpProjectType();
+    Version readVersion = phpProjectType.getCurrentVersion(phpDir, mockProcessHelper);
+
+    // The current version is returned
+    assertThat(readVersion, IsEqual.equalTo(Version.valueOf("0.10.0")));
+  }
+}

--- a/src/test/java/io/jenkins/plugins/conventionalcommits/utils/ProjectTypeTest.java
+++ b/src/test/java/io/jenkins/plugins/conventionalcommits/utils/ProjectTypeTest.java
@@ -137,4 +137,19 @@ public class ProjectTypeTest {
     ProjectType projectType = new GoProjectType();
     assertFalse(projectType.check(goDir));
   }
+
+  @Test
+  public void isPhpProject() throws IOException {
+    File PhpDir = rootFolder.newFolder("SamplePhpProject");
+    rootFolder.newFile(PhpDir.getName() + File.separator + "composer.json");
+    ProjectType projectType = new PhpProjectType();
+    assertEquals(true, projectType.check(PhpDir));
+  }
+
+  @Test
+  public void isNotPhpProject() throws IOException {
+    File PhpDir = rootFolder.newFolder("SamplePhpProject");
+    ProjectType projectType = new PhpProjectType();
+    assertFalse(projectType.check(PhpDir));
+  }
 }


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
## Checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
## Description
Fixes #116. 

I have added code to support reading the current version of PHP trying first to get the version from the `"composer.json"` file as the default, then if this option is not available falls back to using the `git` tags approach to get the current version. 

Also, my other GitHub username is `slim-patchy` and I am transitioning to using my new username `krisstern`, so people know more explicitly who I am. 
