### PR TITLE
Use `jenkins.baseline` to reduce bom update mistakes

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -12,7 +12,9 @@
     <version>0.10.1-SNAPSHOT</version>
     <packaging>hpi</packaging>
     <properties>
-	<jenkins.version>2.332</jenkins.version>
+	<!-- https://www.jenkins.io/doc/developer/plugin-development/choosing-jenkins-baseline/ -->
+	<jenkins.baseline>2.249</jenkins.baseline>
+	<jenkins.version>${jenkins.baseline}.1</jenkins.version>
         <java.level>8</java.level>
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <checkstyle.config.location>google_checks.xml</checkstyle.config.location>
@@ -24,7 +26,7 @@
         <dependencies>
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
-                <artifactId>bom-2.249.x</artifactId>
+                <artifactId>bom-${jenkins.baseline}.x</artifactId>
                 <version>961.vf0c9f6f59827</version>
                 <scope>import</scope>
                 <type>pom</type>


### PR DESCRIPTION
## Use `jenkins.baseline` in `pom.xml`

This change is proposed by the plugin archetype and makes maintenance of `jenkins.version` and `bom` a little easier.

### Testing done

None. Rely on `ci.jenkins.io` to test it.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
